### PR TITLE
Feature/entity table name custom

### DIFF
--- a/src/main/java/com/mini/auction/auction/adapter/out/persistence/AuctionEntity.java
+++ b/src/main/java/com/mini/auction/auction/adapter/out/persistence/AuctionEntity.java
@@ -48,8 +48,7 @@ class AuctionEntity extends BaseJpaEntity {
     private AuctionState state = AuctionState.WAITING;
 
     @Comment("댓글")
-    @Column(name = "comments_id")
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "auction")
-    private List<CommentsEntity> comments = new ArrayList<CommentsEntity>();
+    private List<CommentsEntity> comments = new ArrayList<>();
 
 }

--- a/src/main/java/com/mini/auction/auction/adapter/out/persistence/AuctionEntity.java
+++ b/src/main/java/com/mini/auction/auction/adapter/out/persistence/AuctionEntity.java
@@ -16,7 +16,6 @@ import java.util.List;
 @NoArgsConstructor
 @Getter
 @Entity
-@Table(name = "auction")
 class AuctionEntity extends BaseJpaEntity {
 
     @Comment("판매자 id")

--- a/src/main/java/com/mini/auction/auction/adapter/out/persistence/CommentsEntity.java
+++ b/src/main/java/com/mini/auction/auction/adapter/out/persistence/CommentsEntity.java
@@ -19,7 +19,7 @@ class CommentsEntity extends BaseJpaEntity {
     private String writer;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "auction_id")
+    @JoinColumn
     @Comment("경매글")
     private AuctionEntity auction;
 

--- a/src/main/java/com/mini/auction/auction/adapter/out/persistence/TermsEntity.java
+++ b/src/main/java/com/mini/auction/auction/adapter/out/persistence/TermsEntity.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Entity
-@Table(name = "terms")
 class TermsEntity extends BaseJpaEntity {
 
     @Column

--- a/src/main/java/com/mini/auction/common/CustomNamingStrategy.java
+++ b/src/main/java/com/mini/auction/common/CustomNamingStrategy.java
@@ -10,7 +10,6 @@ public class CustomNamingStrategy extends CamelCaseToUnderscoresNamingStrategy {
     public Identifier toPhysicalTableName(Identifier logicalName, JdbcEnvironment jdbcEnvironment) {
         String originalText = logicalName.getText();
         String customText = originalText.substring(0, originalText.length() - 6);
-        System.out.println("check table naming : " + customText);
         return super.toPhysicalTableName(new Identifier(customText, logicalName.isQuoted()), jdbcEnvironment);
     }
 }

--- a/src/main/java/com/mini/auction/common/CustomNamingStrategy.java
+++ b/src/main/java/com/mini/auction/common/CustomNamingStrategy.java
@@ -1,16 +1,16 @@
 package com.mini.auction.common;
 
+import org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy;
 import org.hibernate.boot.model.naming.Identifier;
-import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 
-public class CustomNamingStrategy extends PhysicalNamingStrategyStandardImpl {
+public class CustomNamingStrategy extends CamelCaseToUnderscoresNamingStrategy {
 
     @Override
-    public Identifier toPhysicalTableName(Identifier logicalName, JdbcEnvironment context) {
+    public Identifier toPhysicalTableName(Identifier logicalName, JdbcEnvironment jdbcEnvironment) {
         String originalText = logicalName.getText();
         String customText = originalText.substring(0, originalText.length() - 6);
         System.out.println("check table naming : " + customText);
-        return new Identifier(customText, logicalName.isQuoted());
+        return super.toPhysicalTableName(new Identifier(customText, logicalName.isQuoted()), jdbcEnvironment);
     }
 }

--- a/src/main/java/com/mini/auction/common/CustomNamingStrategy.java
+++ b/src/main/java/com/mini/auction/common/CustomNamingStrategy.java
@@ -1,0 +1,16 @@
+package com.mini.auction.common;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+
+public class CustomNamingStrategy extends PhysicalNamingStrategyStandardImpl {
+
+    @Override
+    public Identifier toPhysicalTableName(Identifier logicalName, JdbcEnvironment context) {
+        String originalText = logicalName.getText();
+        String customText = originalText.substring(0, originalText.length() - 6);
+        System.out.println("check table naming : " + customText);
+        return new Identifier(customText, logicalName.isQuoted());
+    }
+}

--- a/src/main/java/com/mini/auction/member/adapter/out/persistence/MemberEntity.java
+++ b/src/main/java/com/mini/auction/member/adapter/out/persistence/MemberEntity.java
@@ -3,7 +3,6 @@ package com.mini.auction.member.adapter.out.persistence;
 import com.mini.auction.common.domian.BaseJpaEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/mini/auction/member/adapter/out/persistence/MemberEntity.java
+++ b/src/main/java/com/mini/auction/member/adapter/out/persistence/MemberEntity.java
@@ -16,7 +16,6 @@ import org.hibernate.annotations.Comment;
 @Entity
 @AllArgsConstructor //모든 필드를 매개변수로 받는 생성자를 자동으로 생성
 @NoArgsConstructor(access = AccessLevel.PROTECTED) //기본 생성자 자동 생성, 생성된 생성자는 동일 패키지 내에서 또는 서브클래스에서만 접근할 수 있다.
-@Table(name = "member")
 class MemberEntity extends BaseJpaEntity {
 
     @Comment("이름")

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,9 @@ spring.jpa.defer-datasource-initialization=false
 # ??? warnning ???? ??
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 
+# entity table name custom
+spring.jpa.hibernate.naming.physical-strategy=com.mini.auction.common.CustomNamingStrategy
+
 ## logging
 logging.level.org.hibernate.sql=debug
 logging.level.org.hibernate.type.descriptor.sql.spi=trace


### PR DESCRIPTION
모든 Entity 에 각각 @Table 을 사용하지 않고, 원하는 형태로 DB 에 생성되는 table name 을 custom 하는 방법을 찾았습니다.

CamelCaseToUnderscoresNamingStrategy.class 는 spring boot 의 기본 네이밍 전략입니다. 
CamelCaseToUnderscoresNamingStrategy 가 기본 네이밍 전략이고, 물리적 네이밍 전략이기 때문에 DB table 명을 설정하는 것에 적합하다고 생각하였습니다. 
(여러 네이밍 전략이 있고, 네이밍 전략에 대한 좀 더 자세한 내용은 wiki 에 작성 해놓았습니다. https://github.com/mini-auction/mini-auction/wiki/Workbook)

사실 꼭 할 필요는 없지만, 새로운 것을 시도해본다는 관점에서 작업해 보았습니다. 